### PR TITLE
Local to global conversion

### DIFF
--- a/CUDADataFormats/SiStripCluster/interface/MkFitSiStripClustersCUDA.h
+++ b/CUDADataFormats/SiStripCluster/interface/MkFitSiStripClustersCUDA.h
@@ -1,0 +1,130 @@
+#ifndef CUDADataFormats_SiStripCluster_interface_MkFitSiStripClustersCUDA_h
+#define CUDADataFormats_SiStripCluster_interface_MkFitSiStripClustersCUDA_h
+
+#include "CUDADataFormats/SiStripCluster/interface/GPUtypes.h"
+
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/cudaCompat.h"
+
+#include <cuda_runtime.h>
+
+class MkFitSiStripClustersCUDA {
+public:
+  MkFitSiStripClustersCUDA() = default;
+  explicit MkFitSiStripClustersCUDA(size_t maxClusters, int clustersPerStrip, cudaStream_t stream);
+  ~MkFitSiStripClustersCUDA() = default;
+
+  MkFitSiStripClustersCUDA(const MkFitSiStripClustersCUDA &) = delete;
+  MkFitSiStripClustersCUDA &operator=(const MkFitSiStripClustersCUDA &) = delete;
+  MkFitSiStripClustersCUDA(MkFitSiStripClustersCUDA &&) = default;
+  MkFitSiStripClustersCUDA &operator=(MkFitSiStripClustersCUDA &&) = default;
+
+  void setNClusters(uint32_t nClusters) { nClusters_h = nClusters; }
+
+  uint32_t nClusters() const { return nClusters_h; }
+
+  class GlobalDeviceView {
+  public:
+
+    __device__ __forceinline__ float local_xx(int i) const  { return __ldg(local_xx_ + i); }
+    __device__ __forceinline__ float local_xy(int i) const  { return __ldg(local_xy_ + i); }
+    __device__ __forceinline__ float local_yy(int i) const  { return __ldg(local_yy_ + i); }
+    __device__ __forceinline__ float local(int i) const  { return __ldg(local_ + i); }
+    __device__ __forceinline__ float global_x(int i) const  { return __ldg(global_x_ + i); }
+    __device__ __forceinline__ float global_y(int i) const  { return __ldg(global_y_ + i); }
+    __device__ __forceinline__ float global_z(int i) const  { return __ldg(global_z_ + i); }
+
+    __device__ __forceinline__ float global_xx(int i) const  { return __ldg(global_xx_ + i); }
+    __device__ __forceinline__ float global_xy(int i) const  { return __ldg(global_xy_ + i); }
+    __device__ __forceinline__ float global_xz(int i) const  { return __ldg(global_xz_ + i); }
+    __device__ __forceinline__ float global_yy(int i) const  { return __ldg(global_yy_ + i); }
+    __device__ __forceinline__ float global_yz(int i) const  { return __ldg(global_yz_ + i); }
+    __device__ __forceinline__ float global_zz(int i) const  { return __ldg(global_zz_ + i); }
+
+    __device__ __forceinline__ short layer(int i) const  { return __ldg(layer_ + i); }
+    __device__ __forceinline__ float barycenter(int i) const  { return __ldg(barycenter_ + i); } // to remove Tres
+    __device__ __forceinline__ stripgpu::detId_t clusterDetId(int i) const { return __ldg(clusterDetId_ + i); }
+
+    friend MkFitSiStripClustersCUDA;
+
+    //   private:
+    int nClusters_;
+
+    float *local_xx_;
+    float *local_xy_;
+    float *local_yy_;
+    float *local_;
+    float *global_x_;
+    float *global_y_;
+    float *global_z_;
+
+    float *global_xx_;
+    float *global_xy_;
+    float *global_xz_;
+    float *global_yy_;
+    float *global_yz_;
+    float *global_zz_;
+
+    short *layer_;
+    float *barycenter_; // to remove Tres
+    stripgpu::detId_t *clusterDetId_;
+  };
+
+  GlobalDeviceView *gview() const { return gview_d.get(); }
+
+  class HostView {
+  public:
+    explicit HostView(size_t maxClusters, int clustersPerStrip, cudaStream_t stream);
+
+    cms::cuda::host::unique_ptr<stripgpu::detId_t[]> clusterDetId_h;
+    cms::cuda::host::unique_ptr<float[]> barycenter_h;
+
+    cms::cuda::host::unique_ptr<float[]> local_xx_h;
+    cms::cuda::host::unique_ptr<float[]> local_xy_h;
+    cms::cuda::host::unique_ptr<float[]> local_yy_h;
+    cms::cuda::host::unique_ptr<float[]> local_h;
+    cms::cuda::host::unique_ptr<float[]> global_x_h;
+    cms::cuda::host::unique_ptr<float[]> global_y_h;
+    cms::cuda::host::unique_ptr<float[]> global_z_h;
+    cms::cuda::host::unique_ptr<float[]> global_xx_h;
+    cms::cuda::host::unique_ptr<float[]> global_xy_h;
+    cms::cuda::host::unique_ptr<float[]> global_xz_h;
+    cms::cuda::host::unique_ptr<float[]> global_yy_h;
+    cms::cuda::host::unique_ptr<float[]> global_yz_h;
+    cms::cuda::host::unique_ptr<float[]> global_zz_h;
+
+    cms::cuda::host::unique_ptr<short[]> layer_h;
+    int nClusters_h;
+  };
+
+  std::unique_ptr<HostView> hostView(int clustersPerStrip, cudaStream_t stream) const;
+
+private:
+  cms::cuda::device::unique_ptr<stripgpu::detId_t[]> clusterDetId_d;
+  cms::cuda::device::unique_ptr<float[]> barycenter_d;
+
+  cms::cuda::device::unique_ptr<float[]> local_xx_d;
+  cms::cuda::device::unique_ptr<float[]> local_xy_d;
+  cms::cuda::device::unique_ptr<float[]> local_yy_d;
+  cms::cuda::device::unique_ptr<float[]> local_d;
+  cms::cuda::device::unique_ptr<float[]> global_x_d;
+  cms::cuda::device::unique_ptr<float[]> global_y_d;
+  cms::cuda::device::unique_ptr<float[]> global_z_d;
+  cms::cuda::device::unique_ptr<float[]> global_xx_d;
+  cms::cuda::device::unique_ptr<float[]> global_xy_d;
+  cms::cuda::device::unique_ptr<float[]> global_xz_d;
+  cms::cuda::device::unique_ptr<float[]> global_yy_d;
+  cms::cuda::device::unique_ptr<float[]> global_yz_d;
+  cms::cuda::device::unique_ptr<float[]> global_zz_d;
+
+  cms::cuda::device::unique_ptr<short[]> layer_d;
+
+  cms::cuda::device::unique_ptr<GlobalDeviceView> gview_d;  // "me" pointer
+
+public:
+  int nClusters_h;
+};
+
+
+#endif

--- a/CUDADataFormats/SiStripCluster/src/MkFitSiStripClustersCUDA.cc
+++ b/CUDADataFormats/SiStripCluster/src/MkFitSiStripClustersCUDA.cc
@@ -1,0 +1,93 @@
+#include "CUDADataFormats/SiStripCluster/interface/MkFitSiStripClustersCUDA.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
+
+MkFitSiStripClustersCUDA::MkFitSiStripClustersCUDA(size_t maxClusters, int clustersPerStrip, cudaStream_t stream) {
+  clusterDetId_d = cms::cuda::make_device_unique<stripgpu::detId_t[]>(maxClusters, stream);
+  barycenter_d = cms::cuda::make_device_unique<float[]>(maxClusters, stream);
+
+  local_xx_d  = cms::cuda::make_device_unique<float[]>(maxClusters, stream);
+  local_xy_d  = cms::cuda::make_device_unique<float[]>(maxClusters, stream);
+  local_yy_d  = cms::cuda::make_device_unique<float[]>(maxClusters, stream);
+  local_d  = cms::cuda::make_device_unique<float[]>(maxClusters, stream);
+  global_x_d  = cms::cuda::make_device_unique<float[]>(maxClusters, stream);
+  global_y_d  = cms::cuda::make_device_unique<float[]>(maxClusters, stream);
+  global_z_d  = cms::cuda::make_device_unique<float[]>(maxClusters, stream);
+  global_xx_d = cms::cuda::make_device_unique<float[]>(maxClusters, stream);
+  global_xy_d = cms::cuda::make_device_unique<float[]>(maxClusters, stream);
+  global_xz_d = cms::cuda::make_device_unique<float[]>(maxClusters, stream);
+  global_yy_d = cms::cuda::make_device_unique<float[]>(maxClusters, stream);
+  global_yz_d = cms::cuda::make_device_unique<float[]>(maxClusters, stream);
+  global_zz_d = cms::cuda::make_device_unique<float[]>(maxClusters, stream);
+
+  layer_d = cms::cuda::make_device_unique<short[]>(maxClusters, stream);
+
+  auto gview = cms::cuda::make_host_unique<GlobalDeviceView>(stream);
+  gview->local_xx_ = local_xx_d.get();
+  gview->local_xy_ = local_xy_d.get();
+  gview->local_yy_ = local_yy_d.get();
+  gview->local_ = local_d.get();
+  gview->global_x_ = global_x_d.get();
+  gview->global_y_ = global_y_d.get();
+  gview->global_z_ = global_z_d.get();
+  gview->global_xx_ = global_xx_d.get();
+  gview->global_xy_ = global_xy_d.get();
+  gview->global_xz_ = global_xz_d.get();
+  gview->global_yy_ = global_yy_d.get();
+  gview->global_yz_ = global_yz_d.get();
+  gview->global_zz_ = global_zz_d.get();
+  gview->barycenter_ = barycenter_d.get();//to remove Tres
+  gview->clusterDetId_ = clusterDetId_d.get();
+
+  gview->layer_ = layer_d.get();
+
+  gview_d = cms::cuda::make_device_unique<GlobalDeviceView>(stream);
+  cms::cuda::copyAsync(gview_d, gview, stream);
+}
+
+MkFitSiStripClustersCUDA::HostView::HostView(size_t maxClusters, int clustersPerStrip, cudaStream_t stream) {
+  clusterDetId_h = cms::cuda::make_host_unique<stripgpu::detId_t[]>(maxClusters, stream);
+  barycenter_h = cms::cuda::make_host_unique<float[]>(maxClusters, stream);
+  
+  local_xx_h  = cms::cuda::make_host_unique<float[]>(maxClusters, stream);
+  local_xy_h  = cms::cuda::make_host_unique<float[]>(maxClusters, stream);
+  local_yy_h  = cms::cuda::make_host_unique<float[]>(maxClusters, stream);
+  local_h  = cms::cuda::make_host_unique<float[]>(maxClusters, stream);
+  global_x_h  = cms::cuda::make_host_unique<float[]>(maxClusters, stream);
+  global_y_h  = cms::cuda::make_host_unique<float[]>(maxClusters, stream);
+  global_z_h  = cms::cuda::make_host_unique<float[]>(maxClusters, stream);
+  global_xx_h = cms::cuda::make_host_unique<float[]>(maxClusters, stream);
+  global_xy_h = cms::cuda::make_host_unique<float[]>(maxClusters, stream);
+  global_xz_h = cms::cuda::make_host_unique<float[]>(maxClusters, stream);
+  global_yy_h = cms::cuda::make_host_unique<float[]>(maxClusters, stream);
+  global_yz_h = cms::cuda::make_host_unique<float[]>(maxClusters, stream);
+  global_zz_h = cms::cuda::make_host_unique<float[]>(maxClusters, stream);
+
+  layer_h = cms::cuda::make_host_unique<short[]>(maxClusters, stream);
+
+  nClusters_h = maxClusters;
+}
+
+std::unique_ptr<MkFitSiStripClustersCUDA::HostView> MkFitSiStripClustersCUDA::hostView(int clustersPerStrip, cudaStream_t stream) const {
+  auto view_h = std::make_unique<HostView>(nClusters_h, clustersPerStrip, stream);
+
+  cms::cuda::copyAsync(view_h->clusterDetId_h, clusterDetId_d, nClusters_h, stream);
+  cms::cuda::copyAsync(view_h->barycenter_h, barycenter_d, nClusters_h, stream);
+  
+  cms::cuda::copyAsync(view_h->local_xx_h, local_xx_d, nClusters_h, stream);
+  cms::cuda::copyAsync(view_h->local_xy_h, local_xy_d, nClusters_h, stream);
+  cms::cuda::copyAsync(view_h->local_yy_h, local_yy_d, nClusters_h, stream);
+  cms::cuda::copyAsync(view_h->local_h, local_d, nClusters_h, stream);
+  cms::cuda::copyAsync(view_h->global_x_h, global_x_d, nClusters_h, stream);
+  cms::cuda::copyAsync(view_h->global_y_h, global_y_d, nClusters_h, stream);
+  cms::cuda::copyAsync(view_h->global_z_h, global_z_d, nClusters_h, stream);
+  cms::cuda::copyAsync(view_h->global_xx_h, global_xx_d, nClusters_h, stream);
+  cms::cuda::copyAsync(view_h->global_xy_h, global_xy_d, nClusters_h, stream);
+  cms::cuda::copyAsync(view_h->global_xz_h, global_xz_d, nClusters_h, stream);
+  cms::cuda::copyAsync(view_h->global_yy_h, global_yy_d, nClusters_h, stream);
+  cms::cuda::copyAsync(view_h->global_yz_h, global_yz_d, nClusters_h, stream);
+  cms::cuda::copyAsync(view_h->global_zz_h, global_zz_d, nClusters_h, stream);
+
+  cms::cuda::copyAsync(view_h->layer_h, layer_d, nClusters_h, stream);
+
+  return view_h;
+}

--- a/RecoLocalTracker/SiStripClusterizer/BuildFile.xml
+++ b/RecoLocalTracker/SiStripClusterizer/BuildFile.xml
@@ -7,10 +7,13 @@
 <use name="CondFormats/SiStripObjects"/>
 <use name="CalibFormats/SiStripObjects"/>
 <use name="CalibTracker/Records"/>
+<use name="MagneticField/Records"/>
+<use name="MagneticField/Engine"/>
 <use name="RecoLocalTracker/Records"/>
 <use name="HeterogeneousCore/CUDACore"/>
 <use   name="CUDADataFormats/SiStripCluster"/>
 <use name="cuda"/>
+<use name="mkfit"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoLocalTracker/SiStripClusterizer/interface/MkFitStripInputWrapper.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/MkFitStripInputWrapper.h
@@ -1,0 +1,44 @@
+#ifndef RecoLocalTracker_SiStripClusterizer_MkFitStripInputWrapper_h
+#define RecoLocalTracker_SiStripClusterizer_MkFitStripInputWrapper_h
+
+#include "RecoTracker/MkFit/interface/MkFitHitIndexMap.h"
+
+#include <memory>
+#include <vector>
+
+namespace mkfit {
+  class Hit;
+  class Track;
+  class LayerNumberConverter;
+  using HitVec = std::vector<Hit>;
+//  using TrackVec = std::vector<Track>;
+}  // namespace mkfit
+
+class MkFitStripInputWrapper {
+public:
+  MkFitStripInputWrapper();
+  MkFitStripInputWrapper(//MkFitHitIndexMap hitIndexMap,
+                    std::vector<mkfit::HitVec> hits,
+                    //mkfit::TrackVec seeds,
+                    mkfit::LayerNumberConverter const& lnc);
+  ~MkFitStripInputWrapper();
+
+  MkFitStripInputWrapper(MkFitStripInputWrapper const&) = delete;
+  MkFitStripInputWrapper& operator=(MkFitStripInputWrapper const&) = delete;
+  MkFitStripInputWrapper(MkFitStripInputWrapper&&);
+  MkFitStripInputWrapper& operator=(MkFitStripInputWrapper&&);
+
+  //MkFitHitIndexMap const& hitIndexMap() const { return hitIndexMap_; }
+  //mkfit::TrackVec const& seeds() const { return *seeds_; }
+  std::vector<mkfit::HitVec> const& hits() const { return hits_; }
+  mkfit::LayerNumberConverter const& layerNumberConverter() const { return *lnc_; }
+  unsigned int nlayers() const;
+
+private:
+  //MkFitHitIndexMap hitIndexMap_;
+  std::vector<mkfit::HitVec> hits_;
+  //std::unique_ptr<mkfit::TrackVec> seeds_;            // for pimpl pattern
+  std::unique_ptr<mkfit::LayerNumberConverter> lnc_;  // for pimpl pattern
+};
+
+#endif

--- a/RecoLocalTracker/SiStripClusterizer/plugins/MkFitHitsFromSOAProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/MkFitHitsFromSOAProducer.cc
@@ -1,0 +1,219 @@
+/*
+ */
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "HeterogeneousCore/CUDACore/interface/ScopedContext.h"
+#include "HeterogeneousCore/CUDAServices/interface/CUDAService.h"
+
+//#include "clusterGPU.cuh"
+//#include "localToGlobal.cuh"
+
+#include <memory>
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+#include "DataFormats/TrackerCommon/interface/TrackerDetSide.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h" 
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"                                  
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/StripTopology.h"
+#include "Math/SVector.h"
+#include "Math/SMatrix.h"
+#include "RecoLocalTracker/SiStripClusterizer/interface/MkFitStripInputWrapper.h"
+#include "Hit.h"
+#include "LayerNumberConverter.h"
+#include "CondFormats/SiStripObjects/interface/SiStripBackPlaneCorrection.h"
+#include "CalibTracker/Records/interface/SiStripDependentRecords.h"
+#include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
+#include "CondFormats/DataRecord/interface/SiStripLorentzAngleRcd.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+
+#include "RecoLocalTracker/SiStripClusterizer/plugins/MkFitSiStripHitGPUKernel.h"
+class MkFitSiStripHitsFromSOA final : public edm::stream::EDProducer<edm::ExternalWork> {
+public:
+  explicit MkFitSiStripHitsFromSOA(const edm::ParameterSet& conf) {
+    inputToken_ = consumes<cms::cuda::Product<SiStripClustersCUDA>>(conf.getParameter<edm::InputTag>("ProductLabel"));
+    outputToken_ = produces<edmNew::DetSetVector<SiStripCluster>>();
+    //outputToken_ = produces<std::vector<mkfit::HitVec>>();
+    //outputToken_ = produces<MkFitStripInputWrapper>();
+  }
+
+  void beginRun(const edm::Run&, const edm::EventSetup& es) override { 
+
+    edm::ESHandle<SiStripBackPlaneCorrection> backPlane;
+    es.get<SiStripBackPlaneCorrectionDepRcd>().get(backPlane);
+    const SiStripBackPlaneCorrection* BackPlaneCorrectionMap = backPlane.product();
+    edm::ESHandle<MagneticField> magField;
+    es.get<IdealMagneticFieldRecord>().get(magField);
+    const MagneticField* MagFieldMap = &(*magField);//.product();
+
+    edm::ESHandle<SiStripLorentzAngle> lorentz;
+    es.get<SiStripLorentzAngleRcd>().get("deconvolution",lorentz);
+    const SiStripLorentzAngle* LorentzAngleMap = lorentz.product();
+
+
+
+
+    edm::ESHandle<TrackerGeometry> tkGx;
+    es.get<TrackerDigiGeometryRecord>().get(tkGx);
+    const TrackerGeometry* tkG = tkGx.product();
+    //sort the tracker geometry into barrel and endcap vectors
+    //std::vector<const GeomDet*> rots_barrel;
+    //std::vector<const GeomDet*> rots_endcap;
+    std::vector<std::tuple<unsigned int, float, float,float, float, float,float, float, float,float, float, float,float, float, float,float>> stripUnit;
+    //for( auto det: tkG->detsTIB()){
+    //      rots_barrel.emplace_back(det); 
+    //}
+    //for( auto det: tkG->detsTOB()){
+    //      rots_barrel.emplace_back(det);
+    //}
+    //for( auto det: tkG->detsTID()){
+    //      rots_endcap.emplace_back(det);
+    //}
+    //for( auto det: tkG->detsTEC()){
+    //      rots_endcap.emplace_back(det);
+    //}
+    for( auto dus: tkG->detUnits()){
+      auto rot_num = dus->geographicalId().rawId();
+      auto magField = (dus->surface()).toLocal(MagFieldMap->inTesla(dus->surface().position()));
+      
+      Surface::RotationType rot = dus->surface().rotation();
+      Surface::PositionType pos = dus->surface().position();
+
+      stripUnit.emplace_back(std::make_tuple(rot_num,magField.x(),magField.y(),magField.z(),pos.x(),pos.y(),pos.z(),rot.xx(),rot.xy(),rot.xz(),rot.yx(),rot.yy(),rot.yz(),rot.zx(),rot.zy(),rot.zz()));
+
+      //stripUnit.emplace_back(std::make_tuple(rot_num,magField.x(),magField.y(),magField.z()));
+    }
+    //sort and erase duplicates.
+    //rots_barrel.erase(unique(rots_barrel.begin(),rots_barrel.end()), rots_barrel.end());
+    //rots_endcap.erase(unique(rots_endcap.begin(),rots_endcap.end()), rots_endcap.end());
+    //sort(rots_barrel.begin(),rots_barrel.end(),[](const GeomDet *lhs, const GeomDet *rhs){DetId detl = lhs->geographicalId();DetId detr = rhs->geographicalId(); return detl.rawId() < detr.rawId();});
+    //sort(rots_endcap.begin(),rots_endcap.end(),[](const GeomDet *lhs, const GeomDet *rhs){DetId detl = lhs->geographicalId();DetId detr = rhs->geographicalId(); return detl.rawId() < detr.rawId();});
+
+    //get geometry information (i dont think boundaries are collected in the the tracker collection
+    edm::ESHandle<GeometricDet> GeomDet2;
+    es.get<IdealGeometryRecord>().get(GeomDet2);
+    //sort the tracker geometry into barrel and endcap vectors
+    std::vector<const GeometricDet*> dets_barrel;
+    std::vector<const GeometricDet*> dets_endcap;
+    for (auto& it :GeomDet2->deepComponents()){
+      DetId det = it->geographicalID();
+      //unsigned int det_num = det.rawId();
+
+      int subdet = det.subdetId();
+      if(subdet == 3 || subdet == 5){
+          dets_barrel.emplace_back(it);
+      }else if (subdet ==4 || subdet ==6){
+          dets_endcap.emplace_back(it);                                                                       }
+    }
+    //sort and erase duplicates.
+    dets_barrel.erase(unique(dets_barrel.begin(),dets_barrel.end()), dets_barrel.end());
+    dets_endcap.erase(unique(dets_endcap.begin(),dets_endcap.end()), dets_endcap.end());
+    sort(dets_barrel.begin(),dets_barrel.end(),[](const GeometricDet *lhs, const GeometricDet *rhs){DetId detl = lhs->geographicalID();DetId detr = rhs->geographicalID(); return detl.rawId() < detr.rawId();});
+    sort(dets_endcap.begin(),dets_endcap.end(),[](const GeometricDet *lhs, const GeometricDet *rhs){DetId detl = lhs->geographicalID();DetId detr = rhs->geographicalID(); return detl.rawId() < detr.rawId();});
+    //Load the barrel and endcap geometry into textured memory
+    gpuAlgo_.loadBarrel(dets_barrel,/*rots_barrel,*/BackPlaneCorrectionMap,MagFieldMap,LorentzAngleMap,stripUnit);
+    gpuAlgo_.loadEndcap(dets_endcap,/*rots_endcap,*/BackPlaneCorrectionMap,MagFieldMap,LorentzAngleMap,stripUnit);
+  }
+
+  void acquire(edm::Event const& ev, edm::EventSetup const& es, edm::WaitingTaskWithArenaHolder waitingTaskHolder) override {
+    const auto& wrapper = ev.get(inputToken_);
+
+    // Sets the current device and creates a CUDA stream
+    cms::cuda::ScopedContextAcquire ctx{wrapper, std::move(waitingTaskHolder)};
+
+    const auto& input = ctx.get(wrapper);
+
+    // Queues asynchronous data transfers and kernels to the CUDA stream
+    // returned by cms::cuda::ScopedContextAcquire::stream()
+    gpuAlgo_.makeGlobal(const_cast<SiStripClustersCUDA&>(input),clusters_g,ctx.stream());
+    hostView_x = clusters_g.hostView(kClusterMaxStrips, ctx.stream());
+
+    // Destructor of ctx queues a callback to the CUDA stream notifying
+    // waitingTaskHolder when the queued asynchronous work has finished
+  }
+
+  void produce(edm::Event& ev, const edm::EventSetup& es) override {
+    printf("Running MkFit Hits Producer\n");
+    //cms::cuda::ScopedContextProduce ctx{ctxState_};
+
+    using out_t = edmNew::DetSetVector<SiStripCluster>;
+    std::unique_ptr<out_t> output(new edmNew::DetSetVector<SiStripCluster>());
+    mkfit::LayerNumberConverter lnc{mkfit::TkLayout::phase1};
+
+  std::unique_ptr<MkFitSiStripClustersCUDA::HostView> clust_data = std::move(hostView_x);
+
+    int totalHits = 0;
+    const int nSeedStripsNC = clust_data->nClusters_h;
+    const auto global_x = clust_data->global_x_h.get();
+    const auto global_y = clust_data->global_y_h.get();
+    const auto global_z = clust_data->global_z_h.get();
+    const auto global_xx = clust_data->global_xx_h.get();
+    const auto global_xy = clust_data->global_xy_h.get();
+    const auto global_xz = clust_data->global_xz_h.get();
+    const auto global_yy = clust_data->global_yy_h.get();
+    const auto global_yz = clust_data->global_yz_h.get();
+    const auto global_zz = clust_data->global_zz_h.get();
+    const auto layer = clust_data->layer_h.get();
+    const auto detid = clust_data->clusterDetId_h.get();
+    const auto barycenter = clust_data->barycenter_h.get();//to remove Tres
+    const auto local_xx = clust_data->local_xx_h.get();
+    const auto local_xy = clust_data->local_xy_h.get();
+    const auto local_yy = clust_data->local_yy_h.get();
+    const auto local = clust_data->local_h.get();
+
+
+    edm::ESHandle<TrackerTopology> ttopo;
+    es.get<TrackerTopologyRcd>().get(ttopo);
+    using SVector3 = ROOT::Math::SVector<float, 3>;
+    using SMatrixSym33 = ROOT::Math::SMatrix<float, 3, 3, ROOT::Math::MatRepSym<float, 3>>;
+    std::vector<mkfit::HitVec> mkFitHits(lnc.nLayers());
+    for( int i =0; i< nSeedStripsNC; ++i){
+      if(layer[i]==-1){continue;}// layer number doubles as "bad hit" index
+      SVector3 pos(global_x[i],global_y[i],global_z[i]);
+      SMatrixSym33 err;
+      err.At(0, 0) = global_xx[i];
+      err.At(0, 1) = global_xy[i];
+      err.At(0, 2) = global_xz[i];
+      err.At(1, 1) = global_yy[i];
+      err.At(1, 2) = global_yz[i];
+      err.At(2, 2) = global_zz[i];
+      int subdet = (detid[i] >> 25) & 0x7;
+      bool stereoraw = ttopo->isStereo(detid[i]);
+      bool plusraw = (ttopo->side(detid[i]) == static_cast<unsigned>(TrackerDetSide::PosEndcap));
+      const auto ilay = lnc.convertLayerNumber(subdet,layer[i],false,stereoraw,plusraw); 
+      mkFitHits[ilay].emplace_back(pos,err,totalHits);
+      //printf("%d %d %f %f %f %e %e %e %e %e %e %.20e %.20e %.20e %.20e %d %d %d %d %.20e\n",detid[i],layer[i],pos[0],pos[1],pos[2],global_xx[i],global_xy[i],global_xz[i],global_yy[i],global_yz[i],global_zz[i],local[i],local_xx[i],local_xy[i],local_yy[i], ilay, layer[i],stereoraw,plusraw,barycenter[i]);
+      ++totalHits;
+    }
+   
+    output->shrink_to_fit();
+    ev.put(std::move(output));
+    //ev.put(std::move(mkFitHits));
+    //ev.emplace(outputToken_,std::move(mkFitHits),lnc);
+  }
+
+private:
+  stripgpu::MkFitSiStripHitGPUKernel gpuAlgo_;
+  MkFitSiStripClustersCUDA clusters_g;
+  std::unique_ptr<MkFitSiStripClustersCUDA::HostView> hostView_x;
+
+  edm::EDGetTokenT<cms::cuda::Product<SiStripClustersCUDA>> inputToken_;
+  edm::EDPutTokenT<edmNew::DetSetVector<SiStripCluster>> outputToken_;
+  //edm::EDPutTokenT<std::vector<mkfit::HitVec>> outputToken_;
+  //edm::EDPutTokenT<MkFitStripInputWrapper> outputToken_;
+};
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(MkFitSiStripHitsFromSOA);

--- a/RecoLocalTracker/SiStripClusterizer/plugins/MkFitSiStripHitGPUKernel.h
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/MkFitSiStripHitGPUKernel.h
@@ -1,0 +1,35 @@
+#ifndef RecoLocalTracker_SiStripClusterizer_plugins_MkFitSiStripHitGPUKernel_h
+#define RecoLocalTracker_SiStripClusterizer_plugins_MkFitSiStripHitGPUKernel_h
+
+#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
+#include "clusterGPU.cuh"
+#include "CUDADataFormats/SiStripCluster/interface/MkFitSiStripClustersCUDA.h"
+#include "CUDADataFormats/SiStripCluster/interface/SiStripClustersCUDA.h"
+
+#include "CondFormats/SiStripObjects/interface/SiStripBackPlaneCorrection.h"
+#include "CalibTracker/Records/interface/SiStripDependentRecords.h"
+#include "CondFormats/SiStripObjects/interface/SiStripLorentzAngle.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+
+#include <cuda_runtime.h>
+
+#include <vector>
+#include <memory>
+
+
+namespace stripgpu {
+
+  class MkFitSiStripHitGPUKernel {
+  public:
+    void loadBarrel(const std::vector<const GeometricDet*> dets_barrel, /*const std::vector<const GeomDet*> rots_barrel,*/const SiStripBackPlaneCorrection* BackPlaneCorrectionMap,const MagneticField* MagFieldMap,const SiStripLorentzAngle* LorentzAngleMap,const std::vector<std::tuple<unsigned int,float,float,float,float,float,float,float,float,float,float,float,float,float,float,float>> stripUnit);
+    void loadEndcap(const std::vector<const GeometricDet*> dets_endcap, /*const std::vector<const GeomDet*> rots_endcap,*/const SiStripBackPlaneCorrection* BackPlaneCorrectionMap,const MagneticField* MagFieldMap,const SiStripLorentzAngle* LorentzAngleMap,const std::vector<std::tuple<unsigned int,float,float,float,float,float,float,float,float,float,float,float,float,float,float,float>> stripUnit);
+    void makeGlobal(SiStripClustersCUDA& clusters_d,MkFitSiStripClustersCUDA& clusters_g, cudaStream_t stream);
+  };
+
+}
+#endif

--- a/RecoLocalTracker/SiStripClusterizer/plugins/clusterGPU.cuh
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/clusterGPU.cuh
@@ -2,6 +2,7 @@
 #define _CLUSTER_GPU_KERNEL_
 
 #include "CUDADataFormats/SiStripCluster/interface/GPUtypes.h"
+#include "CUDADataFormats/SiStripCluster/interface/SiStripClustersCUDA.h"
 
 #include <cstdint>
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/localToGlobal.cu
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/localToGlobal.cu
@@ -1,0 +1,756 @@
+#include <stdio.h>
+#include <cub/cub.cuh>
+
+#include "HeterogeneousCore/CUDAUtilities/interface/allocate_device.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/allocate_host.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/currentDevice.h"
+
+#include "HeterogeneousCore/CUDAUtilities/interface/host_unique_ptr.h"
+#include "HeterogeneousCore/CUDAUtilities/interface/device_unique_ptr.h"
+
+#include "HeterogeneousCore/CUDAUtilities/interface/copyAsync.h"
+
+#include "ChanLocsGPU.h"
+#include "SiStripRawToClusterGPUKernel.h"
+#include "clusterGPU.cuh"
+#include "localToGlobal.cuh"
+
+#include "MkFitSiStripHitGPUKernel.h"
+#include "Geometry/CommonTopologies/interface/BowedSurfaceDeformation.h"
+#include "Geometry/CommonTopologies/interface/SurfaceDeformation.h"
+#include "Geometry/CommonTopologies/interface/StripTopology.h"
+#include "Geometry/CommonTopologies/interface/GeomDet.h"
+#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+#include "DataFormats/GeometrySurface/interface/Bounds.h"
+#include "DataFormats/GeometrySurface/interface/TrapezoidalPlaneBounds.h"
+#include "CondFormats/SiStripObjects/interface/SiStripBackPlaneCorrection.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+
+//#define GPU_DEBUG
+//#define GPU_CHECK
+
+namespace stripgpu {
+  __device__ constexpr int maxseeds() { return MAX_SEEDSTRIPS; }
+
+
+//convert detector id to element index in textured arrays
+__host__ __device__ int index_lookup3(const unsigned int detid){
+
+  int hex4 = (detid >> 16) & 0xF;
+  int hex5 = (detid >> 12) & 0xF;
+  int hex6 = (detid >> 8) & 0xF;
+  int hex7 = (detid >> 4) & 0xF;
+  int hex8 = (detid >> 0) & 0xF;
+
+  int shift = -1;
+    if (hex4 == 1){
+      if(hex5 == 1){ shift = 0;}
+      else if (hex5 ==2){ shift = 1;}
+    }else if (hex4 == 0){
+      switch(hex5){
+        case 14: shift = 2;break;
+        case 13: shift = 3;break;
+        case 10: shift = 4;break;
+        case 9: shift = 5;break;
+        case 6: shift = 6;break;
+        case 5: shift = 7;break;
+      }
+    }
+    return shift*4096 + hex6*256 + hex7*16 + hex8;
+}
+
+__host__ __device__ int index_lookup5(const unsigned int detid){
+
+  int hex4 = (detid >> 16) & 0xF;
+  int hex5 = (detid >> 12) & 0xF;
+  int hex6 = (detid >> 8) & 0xF;
+  int hex7 = (detid >> 4) & 0xF;
+  int hex8 = (detid >> 0) & 0xF;
+
+  int shift = -1;
+    if (hex4 == 1){
+      switch(hex5){
+        case 10: shift = 0;break;
+        case 9: shift = 1;break;
+        case 6: shift = 2;break;
+        case 5: shift = 3;break;
+        case 2: shift = 4;break;
+        case 1: shift = 5;break;
+      }
+    }else if(hex4 == 0){
+      switch(hex5){
+        case 14: shift = 6;break;
+        case 13: shift = 7;break;
+        case 10: shift = 8;break;
+        case 9: shift = 9;break;
+        case 6: shift = 10;break;
+        case 5: shift = 11;break;
+      }
+    }
+    return shift*4096 + hex6*256 + hex7*16 + hex8;
+}
+
+__host__ __device__ int index_lookup4(const unsigned int detid){
+
+  int hex5 = (detid >> 12) & 0xF;
+  int hex6 = (detid >> 8) & 0xF;
+  int hex7 = (detid >> 4) & 0xF;
+  int hex8 = (detid >> 0) & 0xF;
+
+  int shift = -1;
+      switch(hex5){
+        case 5: shift = 0;break;
+        case 4: shift = 1;break;
+        case 3: shift = 2;break;
+        case 2: shift = 3;break;
+      }
+    return shift*4096 + hex6*256 + hex7*16 + hex8;
+}
+__host__ __device__ int index_lookup6(const unsigned int detid){
+
+  int hex4 = (detid >> 16) & 0xF;
+  int hex5 = (detid >> 12) & 0xF;
+  int hex6 = (detid >> 8) & 0xF;
+  int hex7 = (detid >> 4) & 0xF;
+  int hex8 = (detid >> 0) & 0xF;
+
+  int shift = -1;
+    switch(hex4){
+      case 10:
+      switch(hex5){
+        case 6: shift = 0;break;
+        case 5: shift = 1;break;
+        case 2: shift = 2;break;
+        case 1: shift = 3;break;
+      }
+      break;
+     case 9:
+      switch(hex5){
+        case 14: shift = 4;break;
+        case 13: shift = 5;break;
+        case 10: shift = 6;break;
+        case 9: shift = 7;break;
+        case 6: shift = 8;break;
+        case 5: shift = 9;break;
+        case 2: shift = 10;break;
+        case 1: shift = 11;break;
+      }
+      break;
+     case 8:
+      switch(hex5){
+        case 14: shift = 12;break;
+        case 13: shift = 13;break;
+        case 10: shift = 14;break;
+        case 9: shift = 15;break;
+        case 6: shift = 16;break;
+        case 5: shift = 17;break;
+      }
+      break;
+     case 6:
+      switch(hex5){
+        case 6: shift = 18;break;
+        case 5: shift = 19;break;
+        case 2: shift = 20;break;
+        case 1: shift = 21;break;
+      }
+      break;
+     case 5 :
+      switch(hex5){
+        case 14: shift = 22;break;
+        case 13: shift = 23;break;
+        case 10: shift = 24;break;
+        case 9: shift = 25;break;
+        case 6: shift = 26;break;
+        case 5: shift = 27;break;
+        case 2: shift = 28;break;
+        case 1: shift = 29;break;
+      }
+      break;
+     case 4 :
+      switch(hex5){
+        case 14: shift = 30;break;
+        case 13: shift = 31;break;
+        case 10: shift = 32;break;
+        case 9: shift = 33;break;
+        case 6: shift = 34;break;
+        case 5: shift = 35;break;
+      }
+      break;
+    }
+    return shift*4096 + hex6*256 + hex7*16 + hex8;
+}
+//// return rotations as a double
+//static __inline__ __device__ double fetchRot(texture<int,1> t_h, texture<int,1> t_l, int i){
+//
+//    int hi = tex1Dfetch(t_h,i);
+//    int lo = tex1Dfetch(t_l,i);
+//    return __hiloint2double(hi,lo);
+//
+//}
+//
+//int double2hiint(double val)
+//{
+//    union {
+//        double val;
+//        struct {
+//            int lo;
+//            int hi;
+//        };
+//    } u;
+//    u.val = val;
+//    return u.hi;
+//}
+//
+//int double2loint(double val)
+//{
+//    union {
+//        double val;
+//        struct {
+//            int lo;
+//            int hi;
+//        };
+//    } u;
+//    u.val = val;
+//    return u.lo;
+//}
+
+__device__ __constant__ float rec_12 = 1.f/12.f;
+__device__ static void getGlobalBarrel(const unsigned int detid, const float strip_num
+                                       ,float* g_x, float* g_y, float* g_z,
+                                       float* g_xx, float* g_xy, float* g_xz,
+                                       float* g_yy, float* g_yz, float* g_zz,int elem, short i
+                                       ,float* l_xx, float* l_xy, float* l_yy, float* local
+){
+      int deti = det_num_bd[i];
+      if (deti == (int)detid){
+        double pitch = pitch_bd[i];
+        double offset = offset_bd[i];
+        double length = len_bd[i];
+        double pos_x = pos_x_bd[i];
+        double pos_y = pos_y_bd[i];
+        double pos_z = pos_z_bd[i];
+        double drift_x = drift_x_bd[i];
+        double thickness = thickness_bd[i];
+        double backPlane = backPlane_bd[i];
+        double R11 = R11_bd[i];
+        double R12 = R12_bd[i];
+        double R13 = R13_bd[i];
+        double R21 = R21_bd[i];
+        double R22 = R22_bd[i];
+        double R23 = R23_bd[i];
+
+        double fullProjection = (drift_x*thickness)/pitch;
+        double localPoint_corrected = (strip_num - 0.5f*(1.f - backPlane)*fullProjection);
+        double localPoint = localPoint_corrected*pitch+offset;
+        double localError_xx = pitch*pitch*rec_12;
+        double localError_yy = length*length*rec_12;
+        double localError_xy = 0;//rec_12*pitch*length;
+
+        double global_x = R11 * localPoint + pos_x;
+        double global_y = R12 * localPoint + pos_y;
+        double global_z = R13 * localPoint + pos_z;
+
+        g_x[elem] = R11 * localPoint + pos_x;
+        g_y[elem] = R12 * localPoint + pos_y;
+        g_z[elem] = R13 * localPoint + pos_z;
+        g_xx[elem] = R11*(R11*localError_xx + R21*localError_xy) + R21*( R11*localError_xy + R21*localError_yy);
+        g_xy[elem] = R11*(R12*localError_xx + R22*localError_xy) + R21*( R12*localError_xy + R22*localError_yy);
+        g_yy[elem] = R12*(R12*localError_xx + R22*localError_xy) + R22*( R12*localError_xy + R22*localError_yy);
+        g_xz[elem] = R11*(R13*localError_xx + R23*localError_xy) + R21*( R13*localError_xy + R23*localError_yy);
+        g_yz[elem] = R12*(R13*localError_xx + R23*localError_xy) + R22*( R13*localError_xy + R23*localError_yy);
+        g_zz[elem] = R13*(R13*localError_xx + R23*localError_xy) + R23*( R13*localError_xy + R23*localError_yy);
+        l_xx[elem] = localError_xx;
+        l_xy[elem] = localError_xy;
+        l_yy[elem] = localError_yy;
+        local[elem] = localPoint;
+    }
+}
+
+__device__ __constant__ float tanPi8 = 0.4142135623730950;
+__device__ __constant__ float pio8 = 3.141592653589793238 / 8;
+__device__ __constant__ float tan15_val1 = 0.33331906795501708984375; 
+__device__ __constant__ float tan15_val2 = 0.135160386562347412109375; 
+__device__ __constant__ float atanclip_val1 = 8.05374449538e-2f; 
+__device__ __constant__ float atanclip_val2 = 1.38776856032E-1f; 
+__device__ __constant__ float atanclip_val3 = 1.99777106478E-1f;
+__device__ __constant__ float atanclip_val4 = 3.33329491539E-1f;
+__device__ static void getGlobalEndcap(const unsigned int detid, const float strip_num
+                                       ,float* g_x, float* g_y, float* g_z,
+                                       float* g_xx, float* g_xy, float* g_xz,
+                                       float* g_yy, float* g_yz, float* g_zz,int elem, short i
+                                       ,float* l_xx, float* l_xy, float* l_yy, float* local
+){
+      int deti = det_num_ed[i];
+      if (deti == (int)detid){
+        int yAx = yAx_ed[i];
+        double rCross = rCross_ed[i];
+        double aw = aw_ed[i];
+        double phi = phi_ed[i];
+        double length =len_ed[i];
+        double pos_x = pos_x_ed[i];
+        double pos_y = pos_y_ed[i];
+        double pos_z = pos_z_ed[i];
+        double R11 = R11_ed[i];
+        double R12 = R12_ed[i];
+        double R13 = R13_ed[i];
+        double R21 = R21_ed[i];
+        double R22 = R22_ed[i];
+        double R23 = R23_ed[i];
+        double drift_x = drift_x_ed[i];
+        double drift_y = drift_y_ed[i];
+        double thickness = thickness_ed[i];
+        double backPlane = backPlane_ed[i];
+
+        double stripAngle = yAx *(phi+strip_num*aw);
+        double tan15 = stripAngle *(1 + (stripAngle*stripAngle) * (tan15_val1 + (stripAngle * stripAngle) * tan15_val2));
+        double localPoint_uncorrected = yAx * rCross* tan15;
+        double x1 =localPoint_uncorrected + 0.5f*drift_x*thickness;
+        double x2 =localPoint_uncorrected - 0.5f*drift_x*thickness;
+        double y1 =rCross+yAx*0.5*drift_y*thickness;
+        double fullProjection_t = (y1 * x1 - y1 * x2) / (y1 * y1 + x1 * x2);
+
+        short sgn = fullProjection_t<0 ? -1: 1;
+        double atanclip = (sgn*fullProjection_t < tanPi8) ? sgn*((((atanclip_val1 * fullProjection_t*fullProjection_t - atanclip_val2) * fullProjection_t*fullProjection_t + atanclip_val3) * fullProjection_t*fullProjection_t - atanclip_val4) * fullProjection_t * fullProjection_t* sgn*fullProjection_t + sgn*fullProjection_t) : sgn*pio8;
+        double fullProjection = atanclip /aw;
+
+        double localPoint_corrected = (strip_num - 0.5f*(1.f - backPlane)*fullProjection);
+        double stripAnglex = yAx *(phi+localPoint_corrected*aw);
+        double tan15x = stripAnglex *(1 + (stripAnglex*stripAnglex) * (tan15_val1 + (stripAnglex * stripAnglex) * tan15_val2));
+        double localPoint = yAx * rCross* tan15x;
+
+        double t2 = tan15*tan15;
+        double tt = rec_12 * rCross*rCross*aw*aw;
+        double rr = rec_12*length*length;
+        double localError_xx = tt+ t2*rr;
+        double localError_yy = tt*t2+rr;
+        double localError_xy = tan15*(rr-tt);
+
+        g_x[elem] = R11 * localPoint + pos_x;
+        g_y[elem] = R12 * localPoint + pos_y;
+        g_z[elem] = R13 * localPoint + pos_z;
+        g_xx[elem] = R11*(R11*localError_xx + R21*localError_xy) + R21*( R11*localError_xy + R21*localError_yy);
+        g_xy[elem] = R11*(R12*localError_xx + R22*localError_xy) + R21*( R12*localError_xy + R22*localError_yy);
+        g_yy[elem] = R12*(R12*localError_xx + R22*localError_xy) + R22*( R12*localError_xy + R22*localError_yy);
+        g_xz[elem] = R11*(R13*localError_xx + R23*localError_xy) + R21*( R13*localError_xy + R23*localError_yy);
+        g_yz[elem] = R12*(R13*localError_xx + R23*localError_xy) + R22*( R13*localError_xy + R23*localError_yy);
+        g_zz[elem] = R13*(R13*localError_xx + R23*localError_xy) + R23*( R13*localError_xy + R23*localError_yy);
+        local[elem] = localPoint;
+        l_xx[elem] = localError_xx;
+        l_xy[elem] = localError_xy;
+        l_yy[elem] = localError_yy;
+    }
+}
+  __global__
+  static void localToGlobal( SiStripClustersCUDA::DeviceView *clust_data_d
+                            ,MkFitSiStripClustersCUDA::GlobalDeviceView *global_data_d
+                            ,const int nStrips
+){
+    float *__restrict__ barycenter = clust_data_d->barycenter_;
+    bool *__restrict__ trueCluster = clust_data_d->trueCluster_;
+    float *__restrict__ local_xx =  global_data_d->local_xx_;
+    float *__restrict__ local_xy =  global_data_d->local_xy_;
+    float *__restrict__ local_yy =  global_data_d->local_yy_;
+    float *__restrict__ local =  global_data_d->local_;
+    float *__restrict__ global_x =  global_data_d->global_x_;
+    float *__restrict__ global_y =  global_data_d->global_y_;
+    float *__restrict__ global_z =  global_data_d->global_z_;
+    float *__restrict__ global_xx = global_data_d->global_xx_;
+    float *__restrict__ global_xy = global_data_d->global_xy_;
+    float *__restrict__ global_xz = global_data_d->global_xz_;
+    float *__restrict__ global_yy = global_data_d->global_yy_;
+    float *__restrict__ global_yz = global_data_d->global_yz_;
+    float *__restrict__ global_zz = global_data_d->global_zz_;
+    short *__restrict__ layer = global_data_d->layer_;
+    float *__restrict__ barycenterg = global_data_d->barycenter_;
+
+    auto detids = clust_data_d->clusterDetId_;
+    auto gdetids = global_data_d->clusterDetId_;
+
+    static const int kSubDetOffset = 25;
+    static const int kSubDetMask = 0x7;
+    for (int i =0; i<nStrips; i++){
+          const auto detid = detids[i];
+          gdetids[i] = detid;
+          const auto subdet = (detid >> kSubDetOffset) & kSubDetMask;
+          short tex_index = -1;
+          layer[i] = -1;
+          if(!trueCluster[i]){continue;}
+          barycenterg[i] = barycenter[i];
+          if (subdet == 3) { //run barrel
+            tex_index = indexer3[index_lookup3(detid)];
+            getGlobalBarrel(detid,barycenter[i]
+                            ,global_x,global_y,global_z,
+                            global_xx,global_xy,global_xz,
+                            global_yy,global_yz,global_zz,i,tex_index
+                            ,local_xx,local_xy,local_yy,local
+                            );
+            layer[i] = ((detid >>14) & 0x7);
+          } else if( subdet == 5 ){// run barrel
+            tex_index = indexer5[index_lookup5(detid)];
+            getGlobalBarrel(detid,barycenter[i]
+                            ,global_x,global_y,global_z,
+                            global_xx,global_xy,global_xz,
+                            global_yy,global_yz,global_zz,i,tex_index
+                            ,local_xx,local_xy,local_yy,local
+                            );
+            layer[i] = ((detid >>14) & 0x7);
+          } else if (subdet == 4) { //run endcap
+            tex_index = indexer4[index_lookup4(detid)];
+            getGlobalEndcap(detid,barycenter[i]
+                            ,global_x,global_y,global_z,
+                            global_xx,global_xy,global_xz,
+                            global_yy,global_yz,global_zz,i,tex_index
+                            ,local_xx,local_xy,local_yy,local
+                            );
+            layer[i] = ((detid >>11) & 0x3);
+          } else if(subdet ==6 ){// run endcap
+            tex_index = indexer6[index_lookup6(detid)];
+            getGlobalEndcap(detid,barycenter[i]
+                            ,global_x,global_y,global_z,
+                            global_xx,global_xy,global_xz,
+                            global_yy,global_yz,global_zz,i,tex_index
+                            ,local_xx,local_xy,local_yy,local
+                            );
+            layer[i] = ((detid >>14) & 0xF);
+          }
+    }
+}
+
+  void MkFitSiStripHitGPUKernel::loadBarrel(const std::vector<const GeometricDet*> dets_barrel, /*const std::vector<const GeomDet*> rots_barrel,*/ const SiStripBackPlaneCorrection* BackPlaneCorrectionMap, const MagneticField* MagFieldMap,const SiStripLorentzAngle* LorentzAngleMap, const std::vector<std::tuple<unsigned int, float, float , float, float, float , float, float, float , float, float, float , float, float, float , float>> stripUnit){
+    printf("LOADING BARREL\n");
+    short* indexer3_h;
+    short* indexer5_h;
+    cudaMallocHost((void**)&indexer3_h,31214*sizeof(short));
+    cudaMallocHost((void**)&indexer5_h,46426*sizeof(short));
+    cudaMemset(indexer3_h,-1,31214*sizeof(short));
+    cudaMemset(indexer5_h,-1,46426*sizeof(short));
+
+    int* det_num_h;
+    double* pitch_h;
+    double* offset_h;
+    double* len_h;
+    double* pos_x_h;
+    double* pos_y_h;
+    double* pos_z_h;
+    double* R11_h;
+    double* R12_h;
+    double* R13_h;
+    double* R21_h;
+    double* R22_h;
+    double* R23_h;
+    double* backPlane_h;
+    double* thickness_h;
+    double* drift_x_h;
+    cudaMallocHost((void**)&det_num_h,DETS_barrel*sizeof(int));
+    cudaMallocHost((void**)&pitch_h,DETS_barrel*sizeof(double));
+    cudaMallocHost((void**)&offset_h,DETS_barrel*sizeof(double));
+    cudaMallocHost((void**)&len_h,DETS_barrel*sizeof(double));
+    cudaMallocHost((void**)&pos_x_h,DETS_barrel*sizeof(double));
+    cudaMallocHost((void**)&pos_y_h,DETS_barrel*sizeof(double));
+    cudaMallocHost((void**)&pos_z_h,DETS_barrel*sizeof(double));
+    cudaMallocHost((void**)&R11_h,DETS_barrel*sizeof(double));
+    cudaMallocHost((void**)&R12_h,DETS_barrel*sizeof(double));
+    cudaMallocHost((void**)&R13_h,DETS_barrel*sizeof(double));
+    cudaMallocHost((void**)&R21_h,DETS_barrel*sizeof(double));
+    cudaMallocHost((void**)&R22_h,DETS_barrel*sizeof(double));
+    cudaMallocHost((void**)&R23_h,DETS_barrel*sizeof(double));
+    cudaMallocHost((void**)&backPlane_h,DETS_barrel*sizeof(double));
+    cudaMallocHost((void**)&drift_x_h,DETS_barrel*sizeof(double));
+    cudaMallocHost((void**)&thickness_h,DETS_barrel*sizeof(double));
+
+    for (auto it = dets_barrel.begin(); it != dets_barrel.end();++it){
+      int i = std::distance(dets_barrel.begin(),it);
+      const GeometricDet* det = dets_barrel[i];
+      det_num_h[i] = det->geographicalID().rawId();
+
+      int nstrip = int(128* det->siliconAPVNum());
+      std::unique_ptr<const Bounds> bounds(det->bounds());
+      len_h[i] = (&(*bounds))->length();
+      double width = (&(*bounds))->width();
+      thickness_h[i] = (&(*bounds))->thickness();
+      pitch_h[i] = width/nstrip;
+      offset_h[i] = -0.5*width;
+      int sub = (det_num_h[i] >> 25) & 0x7;
+      if(sub == 3){
+        indexer3_h[index_lookup3(det_num_h[i])] = i;
+      }else if(sub == 5){
+        indexer5_h[index_lookup5(det_num_h[i])] = i;
+      }
+    }
+
+    for (auto it = stripUnit.begin(); it != stripUnit.end();++it){
+      int j = std::distance(stripUnit.begin(),it);
+      const auto dus = stripUnit[j];
+      
+      auto rot_num = std::get<0>(dus);
+      int i = -1;
+      int sub = (rot_num >> 25) & 0x7;
+      if(sub == 3){
+        int lookup = index_lookup3(rot_num);
+        if(lookup > 31214) {continue;}
+        i = indexer3_h[lookup];
+      }
+      if(sub == 5){
+        int lookup = index_lookup5(rot_num);
+        if(lookup > 46426) {continue;}
+        i = indexer5_h[lookup];
+      }
+      if (i == -1){ continue;}
+      backPlane_h[i] = BackPlaneCorrectionMap->getBackPlaneCorrection(rot_num);
+      double lorentzAngle = LorentzAngleMap->getLorentzAngle(rot_num);
+      drift_x_h[i] = -lorentzAngle*std::get<2>(dus);
+      pos_x_h[i] = std::get<4>(dus);
+      pos_y_h[i] = std::get<5>(dus);
+      pos_z_h[i] = std::get<6>(dus);
+      R11_h[i] = std::get<7>(dus);
+      R12_h[i] = std::get<8>(dus);
+      R13_h[i] = std::get<9>(dus);
+      R21_h[i] = std::get<10>(dus);
+      R22_h[i] = std::get<11>(dus);
+      R23_h[i] = std::get<12>(dus);
+    }
+    short* indexer3_hd;
+    cudaGetSymbolAddress((void**)&indexer3_hd,indexer3);
+    cudaMemcpy(indexer3_hd,indexer3_h,31214*sizeof(short),cudaMemcpyHostToDevice);
+    short* indexer5_hd;
+    cudaGetSymbolAddress((void**)&indexer5_hd,indexer5);
+    cudaMemcpy(indexer5_hd,indexer5_h,46426*sizeof(short),cudaMemcpyHostToDevice);
+
+    int* det_num_hd;
+    cudaGetSymbolAddress((void**)&det_num_hd,det_num_bd);
+    cudaMemcpy(det_num_hd,det_num_h,DETS_barrel*sizeof(int),cudaMemcpyHostToDevice);
+    double* pitch_hd;
+    cudaGetSymbolAddress((void**)&pitch_hd,pitch_bd);
+    cudaMemcpy(pitch_hd,pitch_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+    double* offset_hd;
+    cudaGetSymbolAddress((void**)&offset_hd,offset_bd);
+    cudaMemcpy(offset_hd,offset_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+    double* len_hd;
+    cudaGetSymbolAddress((void**)&len_hd,len_bd);
+    cudaMemcpy(len_hd,len_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+    double* pos_x_hd;
+    cudaGetSymbolAddress((void**)&pos_x_hd,pos_x_bd);
+    cudaMemcpy(pos_x_hd,pos_x_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+    double* pos_y_hd;
+    cudaGetSymbolAddress((void**)&pos_y_hd,pos_y_bd);
+    cudaMemcpy(pos_y_hd,pos_y_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+    double* pos_z_hd;
+    cudaGetSymbolAddress((void**)&pos_z_hd,pos_z_bd);
+    cudaMemcpy(pos_z_hd,pos_z_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+    double* R11_hd;
+    cudaGetSymbolAddress((void**)&R11_hd,R11_bd);
+    cudaMemcpy(R11_hd,R11_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+    double* R12_hd;
+    cudaGetSymbolAddress((void**)&R12_hd,R12_bd);
+    cudaMemcpy(R12_hd,R12_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+    double* R13_hd;
+    cudaGetSymbolAddress((void**)&R13_hd,R13_bd);
+    cudaMemcpy(R13_hd,R13_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+    double* R21_hd;
+    cudaGetSymbolAddress((void**)&R21_hd,R21_bd);
+    cudaMemcpy(R21_hd,R21_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+    double* R22_hd;
+    cudaGetSymbolAddress((void**)&R22_hd,R22_bd);
+    cudaMemcpy(R22_hd,R22_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+    double* R23_hd;
+    cudaGetSymbolAddress((void**)&R23_hd,R23_bd);
+    cudaMemcpy(R23_hd,R23_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+    double* backPlane_hd;
+    cudaGetSymbolAddress((void**)&backPlane_hd,backPlane_bd);
+    cudaMemcpy(backPlane_hd,backPlane_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+    double* thickness_hd;
+    cudaGetSymbolAddress((void**)&thickness_hd,thickness_bd);
+    cudaMemcpy(thickness_hd,thickness_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+    double* drift_x_hd;
+    cudaGetSymbolAddress((void**)&drift_x_hd,drift_x_bd);
+    cudaMemcpy(drift_x_hd,drift_x_h,DETS_barrel*sizeof(double),cudaMemcpyHostToDevice);
+
+}
+  void MkFitSiStripHitGPUKernel::loadEndcap(const std::vector<const GeometricDet*> dets_endcap, /*const std::vector<const GeomDet*> rots_endcap,*/ const SiStripBackPlaneCorrection* BackPlaneCorrectionMap, const MagneticField* MagFieldMap,const SiStripLorentzAngle* LorentzAngleMap, const std::vector<std::tuple<unsigned int, float, float , float, float, float , float, float, float , float, float, float , float, float, float , float>> stripUnit){
+    printf("LOADING EndCap\n");
+    short* indexer4_h;
+    short* indexer6_h;
+    cudaMallocHost((void**)&indexer4_h,16208*sizeof(short));
+    cudaMallocHost((void**)&indexer6_h,145652*sizeof(short));
+    cudaMemset(indexer4_h,-1,16208*sizeof(short));
+    cudaMemset(indexer6_h,-1,145652*sizeof(short));
+
+    int* det_num_h;
+    int* yAx_h;
+    double* backPlane_h;
+    double* thickness_h;
+    double* drift_x_h;
+    double* drift_y_h;
+    double* rCross_h;
+    double* aw_h;
+    double* phi_h;
+    double* len_h;
+    double* pos_x_h;
+    double* pos_y_h;
+    double* pos_z_h;
+    double* R11_h;
+    double* R12_h;
+    double* R13_h;
+    double* R21_h;
+    double* R22_h;
+    double* R23_h;
+    cudaMallocHost((void**)&det_num_h,DETS_endcap*sizeof(int));
+    cudaMallocHost((void**)&yAx_h,DETS_endcap*sizeof(int));
+    cudaMallocHost((void**)&rCross_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&aw_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&phi_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&len_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&pos_x_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&pos_y_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&pos_z_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&R11_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&R12_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&R13_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&R21_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&R22_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&R23_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&backPlane_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&drift_x_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&drift_y_h,DETS_endcap*sizeof(double));
+    cudaMallocHost((void**)&thickness_h,DETS_endcap*sizeof(double));
+
+    for (auto it = dets_endcap.begin(); it != dets_endcap.end();++it){
+      int i = std::distance(dets_endcap.begin(),it);
+      const GeometricDet* det = dets_endcap[i];
+      det_num_h[i] = det->geographicalId().rawId();
+
+      int nstrip = int(128 *det->siliconAPVNum());
+      std::unique_ptr<const Bounds> bounds(det->bounds());
+      yAx_h[i] = (dynamic_cast<const TrapezoidalPlaneBounds*>(&(*bounds)))->yAxisOrientation();
+      len_h[i] = (&(*bounds))->length();
+      thickness_h[i] = (&(*bounds))->thickness();
+      float width = (&(*bounds))->width();
+      float w_halfl = (&(*bounds))->widthAtHalfLength();
+      rCross_h[i] = w_halfl * len_h[i]/(2*(width-w_halfl));
+      aw_h[i] = atan2(w_halfl/2., static_cast<float>(rCross_h[i]))/(nstrip/2);
+      phi_h[i] = -(0.5 *nstrip) *aw_h[i];
+
+      int sub = (det_num_h[i] >> 25) & 0x7;
+      if(sub == 4){
+        indexer4_h[index_lookup4(det_num_h[i])] = i;
+      }else if(sub == 6){
+        indexer6_h[index_lookup6(det_num_h[i])] = i;
+      }
+    }
+    for (auto it = stripUnit.begin(); it != stripUnit.end();++it){
+      int j = std::distance(stripUnit.begin(),it);
+      const auto dus = stripUnit[j];
+      
+      auto rot_num = std::get<0>(dus);
+      int i = -1;
+      int sub = (rot_num >> 25) & 0x7;
+      if(sub == 4){
+        int lookup = index_lookup4(rot_num);
+        if (lookup > 16208){continue;}
+        i = indexer4_h[lookup];
+      }
+      if(sub == 6){
+        int lookup = index_lookup6(rot_num);
+        if (lookup > 145652){continue;}
+        i = indexer6_h[lookup];
+      }
+      if (i == -1){ continue;}
+      backPlane_h[i] = BackPlaneCorrectionMap->getBackPlaneCorrection(rot_num);
+      double lorentzAngle = LorentzAngleMap->getLorentzAngle(rot_num);
+      drift_x_h[i] = -lorentzAngle*std::get<2>(dus);
+      drift_y_h[i] = lorentzAngle*std::get<1>(dus);
+      pos_x_h[i] = std::get<4>(dus);
+      pos_y_h[i] = std::get<5>(dus);
+      pos_z_h[i] = std::get<6>(dus);
+      R11_h[i] = std::get<7>(dus);
+      R12_h[i] = std::get<8>(dus);
+      R13_h[i] = std::get<9>(dus);
+      R21_h[i] = std::get<10>(dus);
+      R22_h[i] = std::get<11>(dus);
+      R23_h[i] = std::get<12>(dus);
+    }
+    short* indexer4_hd;
+    cudaGetSymbolAddress((void**)&indexer4_hd,indexer4);
+    cudaMemcpy(indexer4_hd,indexer4_h,16208*sizeof(short),cudaMemcpyHostToDevice);
+    short* indexer6_hd;
+    cudaGetSymbolAddress((void**)&indexer6_hd,indexer6);
+    cudaMemcpy(indexer6_hd,indexer6_h,145652*sizeof(short),cudaMemcpyHostToDevice);
+
+    int* det_num_hd;
+    cudaGetSymbolAddress((void**)&det_num_hd,det_num_ed);
+    cudaMemcpy(det_num_hd,det_num_h,DETS_endcap*sizeof(int),cudaMemcpyHostToDevice);
+    int* yAx_hd;
+    cudaGetSymbolAddress((void**)&yAx_hd,yAx_ed);
+    cudaMemcpy(yAx_hd,yAx_h,DETS_endcap*sizeof(int),cudaMemcpyHostToDevice);
+    double* rCross_hd;
+    cudaGetSymbolAddress((void**)&rCross_hd,rCross_ed);
+    cudaMemcpy(rCross_hd,rCross_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* aw_hd;
+    cudaGetSymbolAddress((void**)&aw_hd,aw_ed);
+    cudaMemcpy(aw_hd,aw_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* phi_hd;
+    cudaGetSymbolAddress((void**)&phi_hd,phi_ed);
+    cudaMemcpy(phi_hd,phi_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* len_hd;
+    cudaGetSymbolAddress((void**)&len_hd,len_ed);
+    cudaMemcpy(len_hd,len_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+
+    double* pos_x_hd;
+    cudaGetSymbolAddress((void**)&pos_x_hd,pos_x_ed);
+    cudaMemcpy(pos_x_hd,pos_x_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* pos_y_hd;
+    cudaGetSymbolAddress((void**)&pos_y_hd,pos_y_ed);
+    cudaMemcpy(pos_y_hd,pos_y_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* pos_z_hd;
+    cudaGetSymbolAddress((void**)&pos_z_hd,pos_z_ed);
+    cudaMemcpy(pos_z_hd,pos_z_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* R11_hd;
+    cudaGetSymbolAddress((void**)&R11_hd,R11_ed);
+    cudaMemcpy(R11_hd,R11_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* R12_hd;
+    cudaGetSymbolAddress((void**)&R12_hd,R12_ed);
+    cudaMemcpy(R12_hd,R12_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* R13_hd;
+    cudaGetSymbolAddress((void**)&R13_hd,R13_ed);
+    cudaMemcpy(R13_hd,R13_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* R21_hd;
+    cudaGetSymbolAddress((void**)&R21_hd,R21_ed);
+    cudaMemcpy(R21_hd,R21_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* R22_hd;
+    cudaGetSymbolAddress((void**)&R22_hd,R22_ed);
+    cudaMemcpy(R22_hd,R22_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* R23_hd;
+    cudaGetSymbolAddress((void**)&R23_hd,R23_ed);
+    cudaMemcpy(R23_hd,R23_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* backPlane_hd;
+    cudaGetSymbolAddress((void**)&backPlane_hd,backPlane_ed);
+    cudaMemcpy(backPlane_hd,backPlane_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* thickness_hd;
+    cudaGetSymbolAddress((void**)&thickness_hd,thickness_ed);
+    cudaMemcpy(thickness_hd,thickness_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* drift_x_hd;
+    cudaGetSymbolAddress((void**)&drift_x_hd,drift_x_ed);
+    cudaMemcpy(drift_x_hd,drift_x_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+    double* drift_y_hd;
+    cudaGetSymbolAddress((void**)&drift_y_hd,drift_y_ed);
+    cudaMemcpy(drift_y_hd,drift_y_h,DETS_endcap*sizeof(double),cudaMemcpyHostToDevice);
+  }
+
+   
+  void MkFitSiStripHitGPUKernel::makeGlobal(SiStripClustersCUDA& clusters_d_x,MkFitSiStripClustersCUDA& clusters_g_x, cudaStream_t stream) {
+    
+    auto clust_data_d = clusters_d_x.view();
+    const int nStrips = clusters_d_x.nClusters();
+    clusters_g_x = MkFitSiStripClustersCUDA(nStrips, kClusterMaxStrips, stream);
+    clusters_g_x.setNClusters(nStrips);
+    auto global_data_d = clusters_g_x.gview();
+    const int nthreads = 128;
+    const int nSeeds = std::min(MAX_SEEDSTRIPS, nStrips);
+    const int nblocks = (nStrips+nthreads-1)/nthreads;
+    localToGlobal<<<nblocks, nthreads, 0, stream>>>(clust_data_d, global_data_d,nStrips);
+    cudaCheck(cudaGetLastError());
+  }
+
+}

--- a/RecoLocalTracker/SiStripClusterizer/plugins/localToGlobal.cuh
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/localToGlobal.cuh
@@ -1,0 +1,52 @@
+#ifndef _LOCAL_TO_GLOBAL_GPU_KERNEL_
+#define _LOCAL_TO_GLOBAL_GPU_KERNEL_
+
+#include "CUDADataFormats/SiStripCluster/interface/MkFitSiStripClustersCUDA.h"
+
+#include <cstdint>
+
+static constexpr int DETS_barrel = 7932;
+static constexpr int DETS_endcap = 7216;
+
+__device__ short indexer3[31214];
+__device__ short indexer5[46426];
+__device__ short indexer4[16208];
+__device__ short indexer6[145652];
+
+__device__ int det_num_bd[DETS_barrel];
+__device__ double pitch_bd[DETS_barrel];
+__device__ double offset_bd[DETS_barrel];
+__device__ double len_bd[DETS_barrel];
+__device__ double pos_x_bd[DETS_barrel];
+__device__ double pos_y_bd[DETS_barrel];
+__device__ double pos_z_bd[DETS_barrel];
+__device__ double R11_bd[DETS_barrel];
+__device__ double R12_bd[DETS_barrel];
+__device__ double R13_bd[DETS_barrel];
+__device__ double R21_bd[DETS_barrel];
+__device__ double R22_bd[DETS_barrel];
+__device__ double R23_bd[DETS_barrel];
+__device__ double backPlane_bd[DETS_barrel];
+__device__ double thickness_bd[DETS_barrel];
+__device__ double drift_x_bd[DETS_barrel];
+
+__device__ int det_num_ed[DETS_endcap];
+__device__ int yAx_ed[DETS_endcap];
+__device__ double rCross_ed[DETS_endcap];
+__device__ double aw_ed[DETS_endcap];
+__device__ double phi_ed[DETS_endcap];
+__device__ double len_ed[DETS_endcap];
+__device__ double pos_x_ed[DETS_endcap];
+__device__ double pos_y_ed[DETS_endcap];
+__device__ double pos_z_ed[DETS_endcap];
+__device__ double R11_ed[DETS_endcap];
+__device__ double R12_ed[DETS_endcap];
+__device__ double R13_ed[DETS_endcap];
+__device__ double R21_ed[DETS_endcap];
+__device__ double R22_ed[DETS_endcap];
+__device__ double R23_ed[DETS_endcap];
+__device__ double backPlane_ed[DETS_endcap];
+__device__ double thickness_ed[DETS_endcap];
+__device__ double drift_x_ed[DETS_endcap];
+__device__ double drift_y_ed[DETS_endcap];
+#endif

--- a/RecoLocalTracker/SiStripClusterizer/src/MkFitStripInputWrapper.cc
+++ b/RecoLocalTracker/SiStripClusterizer/src/MkFitStripInputWrapper.cc
@@ -1,0 +1,24 @@
+#include "RecoLocalTracker/SiStripClusterizer/interface/MkFitStripInputWrapper.h"
+
+// mkFit includes
+#include "Hit.h"
+#include "LayerNumberConverter.h"
+#include "Track.h"
+
+MkFitStripInputWrapper::MkFitStripInputWrapper() = default;
+
+MkFitStripInputWrapper::MkFitStripInputWrapper(//MkFitHitIndexMap hitIndexMap,
+                                     std::vector<mkfit::HitVec> hits,
+                                     //mkfit::TrackVec seeds,
+                                     mkfit::LayerNumberConverter const& lnc)
+    : //hitIndexMap_{std::move(hitIndexMap)},
+      hits_{std::move(hits)},
+      //seeds_{std::make_unique<mkfit::TrackVec>(std::move(seeds))},
+      lnc_{std::make_unique<mkfit::LayerNumberConverter>(lnc)} {}
+
+MkFitStripInputWrapper::~MkFitStripInputWrapper() = default;
+
+MkFitStripInputWrapper::MkFitStripInputWrapper(MkFitStripInputWrapper&&) = default;
+MkFitStripInputWrapper& MkFitStripInputWrapper::operator=(MkFitStripInputWrapper&&) = default;
+
+unsigned int MkFitStripInputWrapper::nlayers() const { return lnc_->nLayers(); }

--- a/RecoLocalTracker/SiStripClusterizer/src/classes.h
+++ b/RecoLocalTracker/SiStripClusterizer/src/classes.h
@@ -1,0 +1,7 @@
+#ifndef RecoLocalTracker_SiStripClusterizer_classes_h
+#define RecoLocalTracker_SiStripClusterizer_classes_h
+
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "RecoLocalTracker/SiStripClusterizer/interface/MkFitStripInputWrapper.h"
+
+#endif

--- a/RecoLocalTracker/SiStripClusterizer/src/classes_def.xml
+++ b/RecoLocalTracker/SiStripClusterizer/src/classes_def.xml
@@ -1,0 +1,4 @@
+<lcgdict>
+  <class name="MkFitStripInputWrapper" persistent="false"/>
+  <class name="edm::Wrapper<MkFitStripInputWrapper>" persistent="false"/>
+</lcgdict>


### PR DESCRIPTION
local points have been commented out in case we need to go back to it, but only global points and errors are necessary to transfer back and forth between gpu and cpu. to be removed in final cleanup

ClustersfromSOAProducer needs to change the product token to be the mkfit hits vector. printout statements are commented out but not removed completely. to be removed in final cleanup

74/15148 detectors have mismatched counts in hits produced between cmssw and gpu.
Of dets with matched counts, the hits are sorted by global x value and differences between cmssw and gpu global points are found. 
only 36 hits total have a difference greater than 0.1 (1 mm). 
of these 21 hits come from detectors 369121774, 470046964, 436229466 or 402665296 which produced 0 in all places for hits.
of the 15 hits remaining, most are just above 0.1 (no more than 1 cm difference). 
from the 74 mismatched dets, spot checks indicate that produced hits are still close. 